### PR TITLE
Support dummy atoms for Z-matrix to xyz computation

### DIFF
--- a/docs/aqua_chemistry_drivers.rst
+++ b/docs/aqua_chemistry_drivers.rst
@@ -320,7 +320,9 @@ The ``atom`` field can be in xyz format, as per the example below. Here each ato
 with its position in the x, y, z coordinate space. Atoms are separated by the semicolon symbol.
 
 The ``atom`` field can also be in `ZMatrix <https://en.wikipedia.org/wiki/Z-matrix_(chemistry)>`__ format. Here again
-atoms are separate by semicolon. This is an example for H2O (water): "H; O 1 1.08; H 2 1.08 1 107.5"
+atoms are separate by semicolon. This is an example for H2O (water): "H; O 1 1.08; H 2 1.08 1 107.5". Dummy atom(s)
+using symbol 'X' may be added to allow or facilitate conversion to xyz coordinates, as used internally for processing,
+and are removed from the molecule following the conversion.
 
 .. code:: python
 
@@ -373,7 +375,9 @@ geometrical coordinates separated by a blank space.  Atom configurations are sep
 
 The molecule in the ``atoms`` field can also be in `ZMatrix <https://en.wikipedia.org/wiki/Z-matrix_(chemistry)>`__ format.
 Here again atoms are separated by semicolons; within an atom the symbol and positional information separated by spaces.
-This is an example for H2O (water): "H; O 1 1.08; H 2 1.08 1 107.5"
+This is an example for H2O (water): "H; O 1 1.08; H 2 1.08 1 107.5". Dummy atom(s)
+using symbol 'X' may be added to allow or facilitate conversion to xyz coordinates, as used internally for processing,
+and are removed from the molecule following the conversion.
 
 .. code:: python
 

--- a/qiskit_chemistry/drivers/pyquanted/integrals.py
+++ b/qiskit_chemistry/drivers/pyquanted/integrals.py
@@ -169,7 +169,8 @@ def _check_molecule_format(val):
     if atoms is None or len(atoms) < 1:
         raise QiskitChemistryError('Molecule format error: ' + val)
 
-    # Anx xyz format has 4 parts in each atom, if not then do zmatrix convert
+    # An xyz format has 4 parts in each atom, if not then do zmatrix convert
+    # Allows dummy atoms, using symbol 'X' in zmatrix format for coord computation to xyz
     parts = [x.strip() for x in atoms[0].split(' ')]
     if len(parts) != 4:
         try:
@@ -185,7 +186,9 @@ def _check_molecule_format(val):
             new_val = ""
             for i in range(len(xyz)):
                 atm = xyz[i]
-                if i > 0:
+                if atm[0].upper() == 'X':
+                    continue
+                if len(new_val) > 0:
                     new_val += "; "
                 new_val += "{} {} {} {}".format(atm[0], atm[1], atm[2], atm[3])
             return new_val

--- a/qiskit_chemistry/drivers/pyscfd/integrals.py
+++ b/qiskit_chemistry/drivers/pyscfd/integrals.py
@@ -100,11 +100,16 @@ def _check_molecule_format(val):
     if atoms is None or len(atoms) < 1:
         raise QiskitChemistryError('Molecule format error: ' + val)
 
-    # Anx xyz format has 4 parts in each atom, if not then do zmatrix convert
+    # An xyz format has 4 parts in each atom, if not then do zmatrix convert
+    # Allows dummy atoms, using symbol 'X' in zmatrix format for coord computation to xyz
     parts = [x.strip() for x in atoms[0].split(' ')]
     if len(parts) != 4:
         try:
-            return gto.mole.from_zmatrix(val)
+            newval = []
+            for entry in gto.mole.from_zmatrix(val):
+                if entry[0].upper() != 'X':
+                    newval.append(entry)
+            return newval
         except Exception as exc:
             raise QiskitChemistryError('Failed to convert atom string: ' + val) from exc
 


### PR DESCRIPTION
✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

### Summary

Allow dummy atoms, using atom symbol X, in Z-Matrix format that are present solely to assist/allow conversion to xyz format. 

### Details and comments


