### PR TITLE
bug fix for hf when qubit tapering is used and add tests

### DIFF
--- a/qiskit_chemistry/aqua_extensions/components/initial_states/hartree_fock.py
+++ b/qiskit_chemistry/aqua_extensions/components/initial_states/hartree_fock.py
@@ -108,7 +108,6 @@ class HartreeFock(InitialState):
         self._bitstr = None
 
     def _build_bitstr(self):
-        self._num_particles = self._num_particles
 
         half_orbitals = self._num_orbitals // 2
         bitstr = np.zeros(self._num_orbitals, np.bool)
@@ -137,10 +136,10 @@ class HartreeFock(InitialState):
             bitstr = new_bitstr.astype(np.bool)
 
         if self._qubit_tapering:
-            sq_list = np.asarray(self._sq_list)
+            sq_list = len(bitstr) - np.asarray(self._sq_list)
             bitstr = np.delete(bitstr, sq_list)
 
-        self._bitstr = bitstr
+        self._bitstr = bitstr.astype(np.bool)
 
     def construct_circuit(self, mode, register=None):
         """

--- a/test/test_initial_state_hartree_fock.py
+++ b/test/test_initial_state_hartree_fock.py
@@ -54,6 +54,13 @@ class TestInitialStateHartreeFock(QiskitAquaChemistryTestCase):
         self.assertEqual(cct.qasm(), 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[2];\n'
                                      'u3(3.14159265358979,0.0,3.14159265358979) q[0];\n')
 
+    def test_qubits_6_py_lih_cct(self):
+        self.hf = HartreeFock(6, 10, 2, 'parity', True, [1, 2])
+        cct = self.hf.construct_circuit('circuit')
+        self.assertEqual(cct.qasm(), 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[6];\n'
+                                     'u3(3.14159265358979,0.0,3.14159265358979) q[0];\n'
+                                     'u3(3.14159265358979,0.0,3.14159265358979) q[1];\n')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Since the order is from right to left, the sq_list index must be reversed as well.


### Details and comments


