### PR TITLE
Fixing capitalization in word BibTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Qiskit Chemistry was inspired, authored and brought about by the collective work
 Aqua continues to grow with the help and work of [many people](./CONTRIBUTORS.rst), who contribute
 to the project at different levels.
 If you use Qiskit, please cite as per the included
-[BibTex file](https://github.com/Qiskit/qiskit/blob/master/Qiskit.bib).
+[BibTeX file](https://github.com/Qiskit/qiskit/blob/master/Qiskit.bib).
 
 ## License
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
According to http://www.bibtex.org/, the right capitalization for "BibTeX" is this, instead of "BibTex". This PR fixes it.


### Details and comments


