### PR TITLE
Support the ROHF

### DIFF
--- a/qiskit/chemistry/aqua_extensions/components/initial_states/hartree_fock.py
+++ b/qiskit/chemistry/aqua_extensions/components/initial_states/hartree_fock.py
@@ -39,7 +39,7 @@ class HartreeFock(InitialState):
                     'minimum': 1
                 },
                 'num_particles': {
-                    'type': ['integer', 'array'],
+                    'type': ['array', 'integer'],
                     'default': [1, 1],
                     'contains': {
                         'type': 'integer'
@@ -70,7 +70,7 @@ class HartreeFock(InitialState):
         Args:
             num_qubits (int): number of qubits
             num_orbitals (int): number of spin orbitals
-            num_particles (list, int): number of particles, if it is a tuple, the first number is alpha and the second
+            num_particles (list, int): number of particles, if it is a list, the first number is alpha and the second
                                         number if beta.
             qubit_mapping (str): mapping type for qubit operator
             two_qubit_reduction (bool): flag indicating whether or not two qubit is reduced

--- a/qiskit/chemistry/aqua_extensions/components/initial_states/hartree_fock.py
+++ b/qiskit/chemistry/aqua_extensions/components/initial_states/hartree_fock.py
@@ -96,14 +96,14 @@ class HartreeFock(InitialState):
 
         self._num_orbitals = num_orbitals
         if isinstance(num_particles, list):
-            self._num_alphas = num_particles[0]
-            self._num_betas = num_particles[1]
+            self._num_alpha = num_particles[0]
+            self._num_beta = num_particles[1]
         else:
             logger.info("We assume that the number of alphas and betas are the same.")
-            self._num_alphas = num_particles // 2
-            self._num_betas = num_particles // 2
+            self._num_alpha = num_particles // 2
+            self._num_beta = num_particles // 2
 
-        self._num_particles = self._num_alphas + self._num_betas
+        self._num_particles = self._num_alpha + self._num_beta
 
         if self._num_particles > self._num_orbitals:
             raise ValueError("# of particles must be less than or equal to # of orbitals.")
@@ -121,8 +121,8 @@ class HartreeFock(InitialState):
 
         half_orbitals = self._num_orbitals // 2
         bitstr = np.zeros(self._num_orbitals, np.bool)
-        bitstr[-self._num_alphas:] = True
-        bitstr[-(half_orbitals + self._num_betas):-half_orbitals] = True
+        bitstr[-self._num_alpha:] = True
+        bitstr[-(half_orbitals + self._num_beta):-half_orbitals] = True
 
         if self._qubit_mapping == 'parity':
             new_bitstr = bitstr.copy()

--- a/qiskit/chemistry/aqua_extensions/components/variational_forms/uccsd.py
+++ b/qiskit/chemistry/aqua_extensions/components/variational_forms/uccsd.py
@@ -157,9 +157,9 @@ class UCCSD(VariationalForm):
             self._num_alpha = num_particles // 2
             self._num_beta = num_particles // 2
 
-        self._num_particles = self._num_alpha + self._num_beta
+        self._num_particles = [self._num_alpha, self._num_beta]
 
-        if self._num_particles > self._num_orbitals:
+        if sum(self._num_particles) > self._num_orbitals:
             raise ValueError('# of particles must be less than or equal to # of orbitals.')
 
         self._initial_state = initial_state

--- a/qiskit/chemistry/aqua_extensions/components/variational_forms/uccsd.py
+++ b/qiskit/chemistry/aqua_extensions/components/variational_forms/uccsd.py
@@ -157,7 +157,7 @@ class UCCSD(VariationalForm):
             self._num_alpha = num_particles // 2
             self._num_beta = num_particles // 2
 
-        self._num_particles = num_particles
+        self._num_particles = self._num_alpha + self._num_beta
 
         if self._num_particles > self._num_orbitals:
             raise ValueError('# of particles must be less than or equal to # of orbitals.')

--- a/qiskit/chemistry/aqua_extensions/components/variational_forms/uccsd.py
+++ b/qiskit/chemistry/aqua_extensions/components/variational_forms/uccsd.py
@@ -58,7 +58,7 @@ class UCCSD(VariationalForm):
                     'minimum': 1
                 },
                 'num_particles': {
-                    'type': ['integer', 'array'],
+                    'type': ['array', 'integer'],
                     'default': [1, 1],
                     'contains': {
                         'type': 'integer'
@@ -113,7 +113,7 @@ class UCCSD(VariationalForm):
         Args:
             num_orbitals (int): number of spin orbitals
             depth (int): number of replica of basic module
-            num_particles (list, int): number of particles, if it is a tuple, the first number is alpha
+            num_particles (list, int): number of particles, if it is a list, the first number is alpha
                                         and the second number if beta.
             active_occupied (list): list of occupied orbitals to consider as active space
             active_unoccupied (list): list of unoccupied orbitals to consider as active space

--- a/qiskit/chemistry/core/hamiltonian.py
+++ b/qiskit/chemistry/core/hamiltonian.py
@@ -398,8 +398,7 @@ class Hamiltonian(ChemistryOperator):
     def _map_fermionic_operator_to_qubit(fer_op, qubit_mapping, num_particles, two_qubit_reduction):
         qubit_op = fer_op.mapping(map_type=qubit_mapping, threshold=0.00000001)
         if qubit_mapping == 'parity' and two_qubit_reduction:
-            # TODO The two qubit reduction needs to be updated for the [alpha,beta] list
-            qubit_op = qubit_op.two_qubit_reduced_operator(num_particles[0] + num_particles[1])
+            qubit_op = qubit_op.two_qubit_reduced_operator(num_particles)
         return qubit_op
 
     @staticmethod

--- a/qiskit/chemistry/core/hamiltonian.py
+++ b/qiskit/chemistry/core/hamiltonian.py
@@ -200,30 +200,36 @@ class Hamiltonian(ChemistryOperator):
         # the indexes for elimination according to how many orbitals were removed when freezing.
         #
         orbitals_list = list(set(core_list + reduce_list))
-        nel = qmolecule.num_alpha + qmolecule.num_beta
         num_alpha = qmolecule.num_alpha
         num_beta = qmolecule.num_beta
-        new_nel = nel
         new_num_alpha = num_alpha
         new_num_beta = num_beta
         if len(orbitals_list) > 0:
             orbitals_list = np.array(orbitals_list)
             orbitals_list = orbitals_list[(orbitals_list >= 0) & (orbitals_list < qmolecule.num_orbitals)]
 
-            freeze_list = [i for i in orbitals_list if i < nel // 2]
-            freeze_list = np.append(np.array(freeze_list), np.array(freeze_list) + qmolecule.num_orbitals)
+            freeze_list_alpha = [i for i in orbitals_list if i < num_alpha]
+            freeze_list_beta = [i for i in orbitals_list if i < num_beta]
+            freeze_list = np.append(freeze_list_alpha, [i + qmolecule.num_orbitals for i in freeze_list_beta])
 
-            remove_list = [i for i in orbitals_list if i >= nel // 2]
-            remove_list_orig_idx = np.append(np.array(remove_list), np.array(remove_list) + qmolecule.num_orbitals)
-            remove_list = np.append(np.array(remove_list) - int(len(freeze_list)/2), np.array(remove_list) + qmolecule.num_orbitals - len(freeze_list))
+            remove_list_alpha = [i for i in orbitals_list if i >= num_alpha]
+            remove_list_beta = [i for i in orbitals_list if i >= num_beta]
+            rla_adjust = -len(freeze_list_alpha)
+            rlb_adjust = -len(freeze_list_alpha) - len(freeze_list_beta) + qmolecule.num_orbitals
+            remove_list = np.append([i + rla_adjust for i in remove_list_alpha],
+                                    [i + rlb_adjust for i in remove_list_beta])
+
             logger.info("Combined orbital reduction list: {}".format(orbitals_list))
-            logger.info("  converting to spin orbital reduction list: {}".format(np.append(np.array(orbitals_list), np.array(orbitals_list) + qmolecule.num_orbitals)))
+            logger.info("  converting to spin orbital reduction list: {}".format(
+                np.append(np.array(orbitals_list), np.array(orbitals_list) + qmolecule.num_orbitals)))
             logger.info("    => freezing spin orbitals: {}".format(freeze_list))
-            logger.info("    => removing spin orbitals: {} (indexes accounting for freeze {})".format(remove_list_orig_idx, remove_list))
+            logger.info("    => removing spin orbitals: {} (indexes accounting for freeze {})".format(
+                np.append(remove_list_alpha, np.array(remove_list_beta) + qmolecule.num_orbitals), remove_list))
 
-            new_nel -= len(freeze_list)
-            new_num_alpha -= len(freeze_list) // 2
-            new_num_beta -= len(freeze_list) // 2
+            new_num_alpha -= len(freeze_list_alpha)
+            new_num_beta -= len(freeze_list_beta)
+
+        new_nel = [new_num_alpha, new_num_beta]
 
         fer_op = FermionicOperator(h1=qmolecule.one_body_integrals, h2=qmolecule.two_body_integrals)
         fer_op, self._energy_shift, did_shift = Hamiltonian._try_reduce_fermionic_operator(fer_op, freeze_list, remove_list)
@@ -276,7 +282,7 @@ class Hamiltonian(ChemistryOperator):
             algo_input.add_aux_op(op_dipole_y)
             algo_input.add_aux_op(op_dipole_z)
 
-        logger.info('Molecule num electrons: {}, remaining for processing: {}'.format(nel, new_nel))
+        logger.info('Molecule num electrons: {}, remaining for processing: {}'.format([num_alpha, num_beta], new_nel))
         nspinorbs = qmolecule.num_orbitals * 2
         new_nspinorbs = nspinorbs - len(freeze_list) - len(remove_list)
         logger.info('Molecule num spin orbitals: {}, remaining for processing: {}'.format(nspinorbs, new_nspinorbs))
@@ -392,7 +398,8 @@ class Hamiltonian(ChemistryOperator):
     def _map_fermionic_operator_to_qubit(fer_op, qubit_mapping, num_particles, two_qubit_reduction):
         qubit_op = fer_op.mapping(map_type=qubit_mapping, threshold=0.00000001)
         if qubit_mapping == 'parity' and two_qubit_reduction:
-            qubit_op = qubit_op.two_qubit_reduced_operator(num_particles)
+            # TODO The two qubit reduction needs to be updated for the [alpha,beta] list
+            qubit_op = qubit_op.two_qubit_reduced_operator(num_particles[0] + num_particles[1])
         return qubit_op
 
     @staticmethod

--- a/qiskit/chemistry/drivers/__init__.py
+++ b/qiskit/chemistry/drivers/__init__.py
@@ -12,7 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from ._basedriver import BaseDriver, UnitsType
+from ._basedriver import BaseDriver, UnitsType, HFMethodType
 from ._discover_driver import (DRIVERS_ENTRY_POINT,
                                refresh_drivers,
                                register_driver,
@@ -28,6 +28,7 @@ from .pyscfd import PySCFDriver
 
 __all__ = ['BaseDriver',
            'UnitsType',
+           'HFMethodType',
            'DRIVERS_ENTRY_POINT',
            'refresh_drivers',
            'register_driver',

--- a/qiskit/chemistry/drivers/_basedriver.py
+++ b/qiskit/chemistry/drivers/_basedriver.py
@@ -33,6 +33,11 @@ class UnitsType(Enum):
     BOHR = 'Bohr'
 
 
+class HFMethodType(Enum):
+    RHF = 'rhf'
+    ROHF = 'rohf'
+
+
 class BaseDriver(ABC):
     """
     Base class for Drivers.

--- a/qiskit/chemistry/drivers/pyquanted/integrals.py
+++ b/qiskit/chemistry/drivers/pyquanted/integrals.py
@@ -35,7 +35,7 @@ def compute_integrals(atoms,
                       charge,
                       multiplicity,
                       basis,
-                      calc_type='rhf'):
+                      hf_method='rhf'):
     # Get config from input parameters
     # Molecule is in this format xyz as below or in Z-matrix e.g "H; O 1 1.08; H 2 1.08 1 107.5":
     # atoms=H .0 .0 .0; H .0 .0 0.2
@@ -46,10 +46,10 @@ def compute_integrals(atoms,
 
     units = _check_units(units)
     mol = _parse_molecule(atoms, units, charge, multiplicity)
-    calc_type = calc_type.lower()
+    hf_method = hf_method.lower()
 
     try:
-        ehf, enuke, norbs, mohij, mohijkl, orbs, orbs_energy = _calculate_integrals(mol, basis, calc_type)
+        ehf, enuke, norbs, mohij, mohijkl, orbs, orbs_energy = _calculate_integrals(mol, basis, hf_method)
     except Exception as exc:
         raise QiskitChemistryError('Failed electronic structure computation') from exc
 
@@ -83,13 +83,13 @@ def compute_integrals(atoms,
     return _q_
 
 
-def _calculate_integrals(molecule, basis='sto3g', calc_type='rhf'):
+def _calculate_integrals(molecule, basis='sto3g', hf_method='rhf'):
     """Function to calculate the one and two electron terms. Perform a Hartree-Fock calculation in
         the given basis.
     Args:
         molecule : A pyquante2 molecular object.
         basis : The basis set for the electronic structure computation
-        calc_type: rhf, uhf, rohf
+        hf_method: rhf, uhf, rohf
     Returns:
         ehf : Hartree-Fock energy
         enuke: Nuclear repulsion energy
@@ -107,14 +107,14 @@ def _calculate_integrals(molecule, basis='sto3g', calc_type='rhf'):
     # convert overlap integrals to molecular basis
     # calculate the Hartree-Fock solution of the molecule
 
-    if calc_type == 'rhf':
+    if hf_method == 'rhf':
         solver = rhf(molecule, bfs)
-    elif calc_type == 'rohf':
+    elif hf_method == 'rohf':
         solver = rohf(molecule, bfs)
-    elif calc_type == 'uhf':
+    elif hf_method == 'uhf':
         solver = uhf(molecule, bfs)
     else:
-        raise QiskitChemistryError('Invalid calc_type: {}'.format(calc_type))
+        raise QiskitChemistryError('Invalid hf_method type: {}'.format(hf_method))
     logger.debug('Solver name {}'.format(solver.name))
     ehf = solver.converge()
     if hasattr(solver, 'orbs'):

--- a/qiskit/chemistry/drivers/pyquanted/pyquantedriver.py
+++ b/qiskit/chemistry/drivers/pyquanted/pyquantedriver.py
@@ -12,7 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from qiskit.chemistry.drivers import BaseDriver, UnitsType
+from qiskit.chemistry.drivers import BaseDriver, UnitsType, HFMethodType
 from qiskit.chemistry import QiskitChemistryError
 from qiskit.chemistry.drivers.pyquanted.integrals import compute_integrals
 import importlib
@@ -74,6 +74,16 @@ class PyQuanteDriver(BaseDriver):
                              BasisType.B631GSS.value,
                          ]}
                     ]
+                },
+                "hf_method": {
+                    "type": "string",
+                    "default": HFMethodType.RHF.value,
+                    "oneOf": [
+                        {"enum": [
+                            HFMethodType.RHF.value,
+                            HFMethodType.ROHF.value,
+                        ]}
+                    ]
                 }
             },
             "additionalProperties": False
@@ -85,7 +95,8 @@ class PyQuanteDriver(BaseDriver):
                  units=UnitsType.ANGSTROM,
                  charge=0,
                  multiplicity=1,
-                 basis=BasisType.BSTO3G):
+                 basis=BasisType.BSTO3G,
+                 hf_method=HFMethodType.RHF):
         """
         Initializer
         Args:
@@ -94,6 +105,7 @@ class PyQuanteDriver(BaseDriver):
             charge (int): charge
             multiplicity (int): spin multiplicity
             basis (BasisType): sto3g or 6-31g or 6-31g**
+            hf_method (HFMethodType): Hartree-Fock Method type
         """
         if not isinstance(atoms, list) and not isinstance(atoms, str):
             raise QiskitChemistryError("Invalid atom input for PYQUANTE Driver '{}'".format(atoms))
@@ -105,7 +117,7 @@ class PyQuanteDriver(BaseDriver):
 
         units = units.value
         basis = basis.value
-
+        hf_method = hf_method.value
         self.validate(locals())
         super().__init__()
         self._atoms = atoms
@@ -113,6 +125,7 @@ class PyQuanteDriver(BaseDriver):
         self._charge = charge
         self._multiplicity = multiplicity
         self._basis = basis
+        self._hf_method = hf_method
 
     @staticmethod
     def check_driver_valid():
@@ -133,7 +146,7 @@ class PyQuanteDriver(BaseDriver):
         Initialize via section dictionary.
 
         Args:
-            params (dict): section dictionary
+            section (dict): section dictionary
 
         Returns:
             Driver: Driver object
@@ -148,6 +161,8 @@ class PyQuanteDriver(BaseDriver):
                 v = UnitsType(v)
             elif k == PyQuanteDriver.KEY_BASIS:
                 v = BasisType(v)
+            elif k == 'hf_method':
+                v = HFMethodType(v)
 
             kwargs[k] = v
 
@@ -159,4 +174,5 @@ class PyQuanteDriver(BaseDriver):
                                  units=self._units,
                                  charge=self._charge,
                                  multiplicity=self._multiplicity,
-                                 basis=self._basis)
+                                 basis=self._basis,
+                                 hf_method=self._hf_method)

--- a/qiskit/chemistry/drivers/pyscfd/pyscfdriver.py
+++ b/qiskit/chemistry/drivers/pyscfd/pyscfdriver.py
@@ -12,7 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from qiskit.chemistry.drivers import BaseDriver, UnitsType
+from qiskit.chemistry.drivers import BaseDriver, UnitsType, HFMethodType
 from qiskit.chemistry import QiskitChemistryError
 from qiskit.chemistry.drivers.pyscfd.integrals import compute_integrals
 import importlib
@@ -58,6 +58,16 @@ class PySCFDriver(BaseDriver):
                     "type": "string",
                     "default": "sto3g"
                 },
+                "hf_method": {
+                    "type": "string",
+                    "default": HFMethodType.RHF.value,
+                    "oneOf": [
+                        {"enum": [
+                            HFMethodType.RHF.value,
+                            HFMethodType.ROHF.value,
+                        ]}
+                    ]
+                },
                 "max_memory": {
                     "type": ["integer", "null"],
                     "default": None
@@ -73,6 +83,7 @@ class PySCFDriver(BaseDriver):
                  charge=0,
                  spin=0,
                  basis='sto3g',
+                 hf_method=HFMethodType.RHF,
                  max_memory=None):
         """
         Initializer
@@ -82,6 +93,7 @@ class PySCFDriver(BaseDriver):
             charge (int): charge
             spin (int): spin
             basis (str): basis set
+            hf_method (HFMethodType): Hartree-Fock Method type
             max_memory (int): maximum memory
         """
         if not isinstance(atom, list) and not isinstance(atom, str):
@@ -93,6 +105,7 @@ class PySCFDriver(BaseDriver):
             atom = atom.replace('\n', ';')
 
         unit = unit.value
+        hf_method = hf_method.value
         self.validate(locals())
         super().__init__()
         self._atom = atom
@@ -100,11 +113,12 @@ class PySCFDriver(BaseDriver):
         self._charge = charge
         self._spin = spin
         self._basis = basis
+        self._hf_method = hf_method
         self._max_memory = max_memory
 
     @staticmethod
     def check_driver_valid():
-        err_msg = "PySCF is not installed. Use 'pip install pyscf'"
+        err_msg = "PySCF is not installed. See https://sunqm.github.io/pyscf/install.html"
         try:
             spec = importlib.util.find_spec('pyscf')
             if spec is not None:
@@ -121,7 +135,7 @@ class PySCFDriver(BaseDriver):
         Initialize via section dictionary.
 
         Args:
-            params (dict): section dictionary
+            section (dict): section dictionary
 
         Returns:
             Driver: Driver object
@@ -134,6 +148,8 @@ class PySCFDriver(BaseDriver):
         for k, v in params.items():
             if k == 'unit':
                 v = UnitsType(v)
+            elif k == 'hf_method':
+                v = HFMethodType(v)
 
             kwargs[k] = v
 
@@ -146,4 +162,5 @@ class PySCFDriver(BaseDriver):
                                  charge=self._charge,
                                  spin=self._spin,
                                  basis=self._basis,
+                                 hf_method=self._hf_method,
                                  max_memory=self._max_memory)

--- a/qiskit/chemistry/fermionic_operator.py
+++ b/qiskit/chemistry/fermionic_operator.py
@@ -463,10 +463,17 @@ class FermionicOperator(object):
         P. Barkoutsos, arXiv:1805.04340(https://arxiv.org/abs/1805.04340).
 
         Args:
-            num_particles (int): number of particles
+            num_particles (list, int): number of particles, if it is a list, the first number is alpha
+                                       and the second number is beta.
         """
+        if isinstance(num_particles, list):
+            total_particles = num_particles[0]
+            total_particles += num_particles[1]
+        else:
+            total_particles = num_particles
+        # TODO Particle hole transformation should be updated to support alpha & beta numbers
         self._convert_to_interleaved_spins()
-        h1, h2, energy_shift = particle_hole_transformation(self._modes, num_particles,
+        h1, h2, energy_shift = particle_hole_transformation(self._modes, total_particles,
                                                             self._h1, self._h2)
         new_fer_op = FermionicOperator(h1=h1, h2=h2, ph_trans_shift=energy_shift)
         new_fer_op._convert_to_block_spins()

--- a/qiskit/chemistry/mp2info.py
+++ b/qiskit/chemistry/mp2info.py
@@ -163,13 +163,12 @@ def _compute_mp2(qmolecule, threshold):
     terms = {}
     mp2_delta = 0
 
-    num_particles = qmolecule.num_alpha + qmolecule.num_beta
     num_orbitals = qmolecule.num_orbitals
     ints = qmolecule.mo_eri_ints
     oe = qmolecule.orbital_energies
 
     # Orbital indexes given by this method are numbered according to the blocked spin ordering
-    singles, doubles = UCCSD.compute_excitation_lists(num_particles, num_orbitals * 2, same_spin_doubles=True)
+    singles, doubles = UCCSD.compute_excitation_lists([qmolecule.num_alpha, qmolecule.num_beta], num_orbitals * 2, same_spin_doubles=True)
 
     # doubles is list of [from, to, from, to] in spin orbital indexing where alpha runs
     # from 0 to num_orbitals-1, and beta from num_orbitals to num_orbitals*2-1

--- a/test/test_core_hamiltonian.py
+++ b/test/test_core_hamiltonian.py
@@ -38,7 +38,7 @@ class TestCoreHamiltonian(QiskitChemistryTestCase):
         self.assertAlmostEqual(core._energy_shift, energy_shift)
         self.assertAlmostEqual(core._ph_energy_shift, ph_energy_shift)
 
-    def _validate_info(self, core, num_particles=2, num_orbitals=4, actual_two_qubit_reduction=False):
+    def _validate_info(self, core, num_particles=[1, 1], num_orbitals=4, actual_two_qubit_reduction=False):
         self.assertEqual(core.molecule_info, {'num_particles': num_particles,
                                               'num_orbitals': num_orbitals,
                                               'two_qubit_reduction': actual_two_qubit_reduction})

--- a/test/test_core_hamiltonian_orb_reduce.py
+++ b/test/test_core_hamiltonian_orb_reduce.py
@@ -38,7 +38,7 @@ class TestCoreHamiltonianOrbReduce(QiskitChemistryTestCase):
         self.assertAlmostEqual(core._energy_shift, energy_shift)
         self.assertAlmostEqual(core._ph_energy_shift, ph_energy_shift)
 
-    def _validate_info(self, core, num_particles=4, num_orbitals=12, actual_two_qubit_reduction=False):
+    def _validate_info(self, core, num_particles=[2, 2], num_orbitals=12, actual_two_qubit_reduction=False):
         self.assertEqual(core.molecule_info, {'num_particles': num_particles,
                                               'num_orbitals': num_orbitals,
                                               'two_qubit_reduction': actual_two_qubit_reduction})
@@ -79,7 +79,7 @@ class TestCoreHamiltonianOrbReduce(QiskitChemistryTestCase):
                            orbital_reduction=[])
         qubit_op, aux_ops = core.run(self.qmolecule)
         self._validate_vars(core, energy_shift=-7.7962196)
-        self._validate_info(core, num_particles=2, num_orbitals=10)
+        self._validate_info(core, num_particles=[1, 1], num_orbitals=10)
         self._validate_input_object(qubit_op, num_qubits=10, num_paulis=276)
 
     def test_freeze_core_orb_reduction(self):
@@ -90,7 +90,7 @@ class TestCoreHamiltonianOrbReduce(QiskitChemistryTestCase):
                            orbital_reduction=[-3, -2])
         qubit_op, aux_ops = core.run(self.qmolecule)
         self._validate_vars(core, energy_shift=-7.7962196)
-        self._validate_info(core, num_particles=2, num_orbitals=6)
+        self._validate_info(core, num_particles=[1, 1], num_orbitals=6)
         self._validate_input_object(qubit_op, num_qubits=6, num_paulis=118)
 
     def test_freeze_core_all_reduction(self):
@@ -101,7 +101,7 @@ class TestCoreHamiltonianOrbReduce(QiskitChemistryTestCase):
                            orbital_reduction=[-3, -2])
         qubit_op, aux_ops = core.run(self.qmolecule)
         self._validate_vars(core, energy_shift=-7.7962196)
-        self._validate_info(core, num_particles=2, num_orbitals=6, actual_two_qubit_reduction=True)
+        self._validate_info(core, num_particles=[1, 1], num_orbitals=6, actual_two_qubit_reduction=True)
         self._validate_input_object(qubit_op, num_qubits=4, num_paulis=100)
 
     def test_freeze_core_all_reduction_ph(self):
@@ -112,7 +112,7 @@ class TestCoreHamiltonianOrbReduce(QiskitChemistryTestCase):
                            orbital_reduction=[-2, -1])
         qubit_op, aux_ops = core.run(self.qmolecule)
         self._validate_vars(core, energy_shift=-7.7962196, ph_energy_shift=-1.05785247)
-        self._validate_info(core, num_particles=2, num_orbitals=6, actual_two_qubit_reduction=True)
+        self._validate_info(core, num_particles=[1, 1], num_orbitals=6, actual_two_qubit_reduction=True)
         self._validate_input_object(qubit_op, num_qubits=4, num_paulis=52)
 
 

--- a/test/test_initial_state_hartree_fock.py
+++ b/test/test_initial_state_hartree_fock.py
@@ -23,19 +23,19 @@ from qiskit.chemistry.aqua_extensions.components.initial_states import HartreeFo
 class TestInitialStateHartreeFock(QiskitChemistryTestCase):
 
     def test_qubits_4_jw_h2(self):
-        self.hf = HartreeFock(4, 4, 2, 'jordan_wigner', False)
+        self.hf = HartreeFock(4, 4, [1, 1], 'jordan_wigner', False)
         cct = self.hf.construct_circuit('vector')
         np.testing.assert_array_equal(cct, [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
                                             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 
     def test_qubits_4_py_h2(self):
-        self.hf = HartreeFock(4, 4, 2, 'parity', False)
+        self.hf = HartreeFock(4, 4, [1, 1], 'parity', False)
         cct = self.hf.construct_circuit('vector')
         np.testing.assert_array_equal(cct, [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
                                             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
 
     def test_qubits_4_bk_h2(self):
-        self.hf = HartreeFock(4, 4, 2, 'bravyi_kitaev', False)
+        self.hf = HartreeFock(4, 4, [1, 1], 'bravyi_kitaev', False)
         cct = self.hf.construct_circuit('vector')
         np.testing.assert_array_equal(cct, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
                                             0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
@@ -46,13 +46,13 @@ class TestInitialStateHartreeFock(QiskitChemistryTestCase):
         np.testing.assert_array_equal(cct, [0.0, 1.0, 0.0, 0.0])
 
     def test_qubits_2_py_h2_cct(self):
-        self.hf = HartreeFock(2, 4, 2, 'parity', True)
+        self.hf = HartreeFock(2, 4, [1, 1], 'parity', True)
         cct = self.hf.construct_circuit('circuit')
         self.assertEqual(cct.qasm(), 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[2];\n'
                                      'u3(3.14159265358979,0.0,3.14159265358979) q[0];\n')
 
     def test_qubits_6_py_lih_cct(self):
-        self.hf = HartreeFock(6, 10, 2, 'parity', True, [1, 2])
+        self.hf = HartreeFock(6, 10, [1, 1], 'parity', True, [1, 2])
         cct = self.hf.construct_circuit('circuit')
         self.assertEqual(cct.qasm(), 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[6];\n'
                                      'u3(3.14159265358979,0.0,3.14159265358979) q[0];\n'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Support ROHF in the driver.
In order to the experiment with ROHF or UHF, we need to split the `num_particles` into `num_alpha` and `num_beta` and update `HartreeFock` and `UCCSD` accordingly.

Furthermore, this PR in aqua is needed to make two qubit reduction of parity mapping work correctly.  
https://github.com/Qiskit/qiskit-aqua/pull/537

### Details and comments


