### PR TITLE
fix hf_state of bk mapping when number of qubits are not power of 2 

### DIFF
--- a/qiskit/chemistry/aqua_extensions/components/initial_states/hartree_fock.py
+++ b/qiskit/chemistry/aqua_extensions/components/initial_states/hartree_fock.py
@@ -140,8 +140,8 @@ class HartreeFock(InitialState):
             for i in range(binary_superset_size):
                 beta = np.kron(basis, beta)
                 beta[0, :] = 1
-
-            beta = beta[:self._num_orbitals, :self._num_orbitals]
+            start_idx = beta.shape[0] - self._num_orbitals
+            beta = beta[start_idx:, start_idx:]
             new_bitstr = beta.dot(bitstr.astype(int)) % 2
             bitstr = new_bitstr.astype(np.bool)
 


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
1. As title, hf_state of bk mapping was only working when the number of qubits is the power of 2.
2. Add more tests


### Details and comments


