### PR TITLE
Adapt to support latest PySCF 1.6.2

### DIFF
--- a/qiskit/chemistry/drivers/pyscfd/integrals.py
+++ b/qiskit/chemistry/drivers/pyscfd/integrals.py
@@ -152,7 +152,7 @@ def _calculate_integrals(mol, hf_method='rhf', conv_tol=1e-9, max_cycle=50, init
         orbs_energy_B = mf.mo_energy[1]
     else:
         # See PYSCF 1.6.2 comment above - this was similarly changed
-        if len(mf.mo_coeff.shape) > 1:
+        if len(mf.mo_energy.shape) > 1:
             orbs_energy = mf.mo_energy[0]
             orbs_energy_B = mf.mo_energy[1]
         else:

--- a/qiskit/chemistry/drivers/pyscfd/integrals.py
+++ b/qiskit/chemistry/drivers/pyscfd/integrals.py
@@ -133,18 +133,31 @@ def _calculate_integrals(mol, hf_method='rhf', conv_tol=1e-9, max_cycle=50, init
         # mo_occ   = mf.mo_occ[0]
         # mo_occ_B = mf.mo_occ[1]
     else:
-        mo_coeff = mf.mo_coeff
-        mo_coeff_B = None
-        # mo_occ   = mf.mo_occ
-        # mo_occ_B = None
+        # With PySCF 1.6.2, instead of a tuple of 2 dimensional arrays, its a 3 dimensional
+        # array with the first dimension indexing to the coeff arrays for alpha and beta
+        if len(mf.mo_coeff.shape) > 2:
+            mo_coeff = mf.mo_coeff[0]
+            mo_coeff_B = mf.mo_coeff[1]
+            # mo_occ   = mf.mo_occ[0]
+            # mo_occ_B = mf.mo_occ[1]
+        else:
+            mo_coeff = mf.mo_coeff
+            mo_coeff_B = None
+            # mo_occ   = mf.mo_occ
+            # mo_occ_B = None
     norbs = mo_coeff.shape[0]
 
     if type(mf.mo_energy) is tuple:
         orbs_energy = mf.mo_energy[0]
         orbs_energy_B = mf.mo_energy[1]
     else:
-        orbs_energy = mf.mo_energy
-        orbs_energy_B = None
+        # See PYSCF 1.6.2 comment above - this was similarly changed
+        if len(mf.mo_coeff.shape) > 1:
+            orbs_energy = mf.mo_energy[0]
+            orbs_energy_B = mf.mo_energy[1]
+        else:
+            orbs_energy = mf.mo_energy
+            orbs_energy_B = None
 
     hij = mf.get_hcore()
     mohij = np.dot(np.dot(mo_coeff.T, hij), mo_coeff)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ h5py
 psutil>=5
 jsonschema>=2.6,<2.7
 networkx>=2.2
-pyscf!=1.6.2; sys_platform != 'win32'
+pyscf; sys_platform != 'win32'
 setuptools>=40.1.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requirements = [
     "psutil>=5",
     "jsonschema>=2.6,<2.7",
     "networkx>=2.2",
-    "pyscf!=1.6.2; sys_platform != 'win32'",
+    "pyscf; sys_platform != 'win32'",
     "setuptools>=40.1.0"
 ]
 


### PR DESCRIPTION
PySCF 1.6.2 now passes back a 3 dimensional array instead of a tuple of 2 dimensional arrays for molecular orbital coefficients. This behavior has now been accommodated in the driver to support 1.6.2 correctly.